### PR TITLE
Small tap area skip and next button

### DIFF
--- a/src/SymbolButton.js
+++ b/src/SymbolButton.js
@@ -6,7 +6,11 @@ const SymbolButton = ({ size, onPress, style, textStyle, children }) => (
   <View
     style={{ height: size, width: size, justifyContent: 'center', ...style }}
   >
-    <TouchableOpacity style={{ flex: 0 }} onPress={onPress}>
+    <TouchableOpacity 
+      style={{ flex: 0 }} 
+      onPress={onPress}
+      hitSlop={{ top: 15, bottom: 15, left: 15, right: 15 }}
+    >
       <Text style={{ textAlign: 'center', fontSize: size / 1.7, ...textStyle }}>
         {children}
       </Text>

--- a/src/TextButton.js
+++ b/src/TextButton.js
@@ -4,7 +4,11 @@ import PropTypes from 'prop-types';
 
 const TextButton = ({ size, onPress, textStyle, children }) => (
   <View style={{ flex: 0 }}>
-    <TouchableOpacity style={{ flex: 0 }} onPress={onPress}>
+    <TouchableOpacity 
+      style={{ flex: 0 }} 
+      onPress={onPress}
+      hitSlop={{ top: 15, bottom: 15, left: 15, right: 15 }}
+    >
       <Text style={{ fontSize: size / 2.5, ...textStyle }}>{children}</Text>
     </TouchableOpacity>
   </View>


### PR DESCRIPTION
Thanks for sharing, Is it possible to increase touchable area of control buttons?

to see what it looks like: https://exp.host/@nattatorn-dev/expo-react-native-onboarding-swiper