### PR TITLE
Add toString to keyExtractor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ class Onboarding extends Component {
     this.setState({ width, height });
   };
 
-  keyExtractor = (item, index) => index;
+  keyExtractor = (item, index) => index.toString();
 
   renderItem = ({ item }) => {
     const { image, title, subtitle, backgroundColor } = item;


### PR DESCRIPTION
For this error: 

`Warning: Failed child context type: Invalid child context `virtualizedCell.cellKey` of type `number` supplied to `CellRenderer`, expected `string`.
`
Changed keyExtractor line to:

`keyExtractor = (item, index) => index.toString();`

