### PR TITLE
Add controlStatusBar prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Also check out the three examples files: the [simple example](examples/Simple.js
 * `bottomBarHeight` (optional): a number for the height of the bottom bar. Defaults to `60`.
 * `bottomBarHighlight` (optional): a bool flag indicating whether the bottm bar should be highlighted. Defaults to `true`.
 * `imageContainerStyles` (optional): for a page in the `pages` array, you can override the default styles e.g. the `paddingBottom` of 60.
+* `controlStatusBar` (optional): a bool flag indicating whether the status bar should change with the background color. Defaults to `true`.
 
 ## Custom Components Properties
 

--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,7 @@ class Onboarding extends Component {
       alterBottomColor,
       bottomBarHeight,
       bottomBarHighlight,
+      controlStatusBar,
       showSkip,
       showNext,
       showDone,
@@ -128,7 +129,7 @@ class Onboarding extends Component {
         onLayout={this._onLayout}
         style={{ flex: 1, backgroundColor, justifyContent: 'center' }}
       >
-        <StatusBar barStyle={this.state.gone ? 'default' : barStyle} />
+        { controlStatusBar && <StatusBar barStyle={this.state.gone ? 'default' : barStyle} /> }
         <FlatList
           ref={list => {
             this.flatList = list;
@@ -207,6 +208,7 @@ Onboarding.propTypes = {
 Onboarding.defaultProps = {
   bottomBarHighlight: true,
   bottomBarHeight: 60,
+  controlStatusBar: true,
   showSkip: true,
   showNext: true,
   showDone: true,


### PR DESCRIPTION
Allows user to remove the StatusBar component by specifying the "controlStatusBar" prop to false.

This is desired when the user wants to control the StatusBar on their own, or use UIViewControllerBasedStatusBarAppearance = YES with a navigation/routing package (for example, wix/react-native-navigation).

Resolves #16 