### PR TITLE
Add allowFontScaling props & style props for title / subtitle

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -53,8 +53,8 @@ Page.propTypes = {
   subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
     .isRequired,
   allowFontScaling: PropTypes.bool,
-  titleStyles: ViewPropTypes.style,
-  subTitleStyles: ViewPropTypes.style,
+  titleStyles: Text.propTypes.style,
+  subTitleStyles: Text.propTypes.style,
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
 };

--- a/src/Page.js
+++ b/src/Page.js
@@ -10,12 +10,15 @@ const Page = ({
   width,
   height,
   imageContainerStyles,
+  allowFontScaling,
+  titleStyles,
+  subTitleStyles,
 }) => {
   let titleElement = title;
   if (typeof title === 'string' || title instanceof String) {
     titleElement = (
       <View style={styles.padding}>
-        <Text style={[styles.title, isLight ? styles.titleLight : {}]}>
+        <Text allowFontScaling={allowFontScaling} style={[styles.title, isLight ? styles.titleLight : {}, titleStyles]}>
           {title}
         </Text>
       </View>
@@ -26,7 +29,7 @@ const Page = ({
   if (typeof subtitle === 'string' || subtitle instanceof String) {
     subtitleElement = (
       <View style={styles.padding}>
-        <Text style={[styles.subtitle, isLight ? styles.subtitleLight : {}]}>
+        <Text allowFontScaling={allowFontScaling} style={[styles.subtitle, isLight ? styles.subtitleLight : {}, subTitleStyles]}>
           {subtitle}
         </Text>
       </View>
@@ -49,12 +52,18 @@ Page.propTypes = {
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
     .isRequired,
+  allowFontScaling: PropTypes.bool,
+  titleStyles: ViewPropTypes.style,
+  subTitleStyles: ViewPropTypes.style,
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
 };
 
 Page.defaultProps = {
   imageContainerStyles: null,
+  allowFontScaling: true,
+  titleStyles: null,
+  subTitleStyles: null,
 };
 
 const { width, height } = Dimensions.get('window');

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -18,6 +18,7 @@ const Pagination = ({
   onDone,
   skipLabel,
   nextLabel,
+  allowFontScaling,
   SkipButtonComponent,
   NextButtonComponent,
   DoneButtonComponent,
@@ -30,6 +31,7 @@ const Pagination = ({
       <SkipButtonComponent
         isLight={isLight}
         skipLabel={skipLabel}
+		allowFontScaling={allowFontScaling}
         onPress={() => {
           if (typeof onSkip === 'function') {
             if (controlStatusBar) {
@@ -45,6 +47,7 @@ const Pagination = ({
     !isLastPage && (
       <NextButtonComponent
         nextLabel={nextLabel}
+		allowFontScaling={allowFontScaling}
         isLight={isLight}
         onPress={onNext}
       />
@@ -54,6 +57,7 @@ const Pagination = ({
     isLastPage && (
       <DoneButtonComponent
         isLight={isLight}
+		allowFontScaling={allowFontScaling}
         onPress={() => {
           if (typeof onDone === 'function') {
             if (controlStatusBar) {
@@ -99,6 +103,7 @@ Pagination.propTypes = {
   onNext: PropTypes.func.isRequired,
   onSkip: PropTypes.func,
   onDone: PropTypes.func,
+  allowFontScaling: PropTypes.bool,
   skipLabel: PropTypes.oneOfType([PropTypes.element, PropTypes.string])
     .isRequired,
   nextLabel: PropTypes.oneOfType([PropTypes.element, PropTypes.string])

--- a/src/buttons/SymbolButton.js
+++ b/src/buttons/SymbolButton.js
@@ -21,7 +21,7 @@ const SymbolButton = ({ size, onPress, style, textStyle, children }) => (
       onPress={onPress}
       hitSlop={{ top: 15, bottom: 15, left: 15, right: 15 }}
     >
-      <Text style={{ textAlign: 'center', fontSize: size / 1.7, ...textStyle }}>
+      <Text allowFontScaling={false} style={{ textAlign: 'center', fontSize: size / 1.7, ...textStyle }}>
         {children}
       </Text>
     </TouchableOpacity>

--- a/src/buttons/TextButton.js
+++ b/src/buttons/TextButton.js
@@ -2,14 +2,14 @@ import { View, TouchableOpacity, Text } from 'react-native';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const TextButton = ({ size, onPress, textStyle, style, children }) => (
+const TextButton = ({ size, onPress, textStyle, allowFontScaling, style, children }) => (
   <View style={{ flex: 0, paddingHorizontal: 10, ...style }}>
     <TouchableOpacity
       style={{ flex: 0 }}
       onPress={onPress}
       hitSlop={{ top: 15, bottom: 15, left: 15, right: 15 }}
     >
-      <Text style={{ fontSize: size / 2.5, ...textStyle }}>{children}</Text>
+      <Text allowFontScaling={allowFontScaling} style={{ fontSize: size / 2.5, ...textStyle }}>{children}</Text>
     </TouchableOpacity>
   </View>
 );
@@ -18,10 +18,12 @@ TextButton.propTypes = {
   size: PropTypes.number.isRequired,
   onPress: PropTypes.func.isRequired,
   textStyle: Text.propTypes.style,
+  allowFontScaling: PropTypes.bool,
 };
 
 TextButton.defaultProps = {
   textStyle: null,
+  allowFontScaling: true,
 };
 
 export default TextButton;

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,9 @@ class Onboarding extends Component {
         width={this.state.width || Dimensions.get('window').width}
         height={this.state.height || Dimensions.get('window').height}
         imageContainerStyles={this.props.imageContainerStyles}
+        allowFontScaling={this.props.allowFontScaling}
+        titleStyles={this.props.titleStyles}
+		subTitleStyles={this.props.subTitleStyles}
       />
     );
   };
@@ -219,6 +222,9 @@ Onboarding.propTypes = {
   NextButtonComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   DotComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   imageContainerStyles: ViewPropTypes.style,
+  allowFontScaling: PropTypes.bool,
+  titleStyles: ViewPropTypes.style,
+  subTitleStyles: ViewPropTypes.style,
   transitionAnimationDuration: PropTypes.number,
   skipToPage: PropTypes.number,
 };
@@ -239,6 +245,9 @@ Onboarding.defaultProps = {
   NextButtonComponent: NextButton,
   DotComponent: Dot,
   imageContainerStyles: null,
+  allowFontScaling: true,
+  titleStyles: null,
+  subTitleStyles: null,
   transitionAnimationDuration: 500,
   skipToPage: null,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import {
   StatusBar,
   SafeAreaView,
   ViewPropTypes,
+  Text,
 } from 'react-native';
 
 import PropTypes from 'prop-types';
@@ -81,7 +82,7 @@ class Onboarding extends Component {
         width={this.state.width || Dimensions.get('window').width}
         height={this.state.height || Dimensions.get('window').height}
         imageContainerStyles={this.props.imageContainerStyles}
-        allowFontScaling={this.props.allowFontScaling}
+        allowFontScaling={this.props.allowFontScalingText}
         titleStyles={this.props.titleStyles}
 		subTitleStyles={this.props.subTitleStyles}
       />
@@ -101,6 +102,7 @@ class Onboarding extends Component {
       onDone,
       skipLabel,
       nextLabel,
+      allowFontScalingButtons,
       SkipButtonComponent,
       DoneButtonComponent,
       NextButtonComponent,
@@ -182,6 +184,7 @@ class Onboarding extends Component {
             onNext={this.goNext}
             skipLabel={skipLabel}
             nextLabel={nextLabel}
+            allowFontScaling={allowFontScalingButtons}
             SkipButtonComponent={SkipButtonComponent}
             DoneButtonComponent={DoneButtonComponent}
             NextButtonComponent={NextButtonComponent}
@@ -222,9 +225,10 @@ Onboarding.propTypes = {
   NextButtonComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   DotComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   imageContainerStyles: ViewPropTypes.style,
-  allowFontScaling: PropTypes.bool,
-  titleStyles: ViewPropTypes.style,
-  subTitleStyles: ViewPropTypes.style,
+  allowFontScalingText: PropTypes.bool,
+  allowFontScalingButtons: PropTypes.bool,
+  titleStyles: Text.propTypes.style,
+  subTitleStyles: Text.propTypes.style,
   transitionAnimationDuration: PropTypes.number,
   skipToPage: PropTypes.number,
 };
@@ -245,7 +249,8 @@ Onboarding.defaultProps = {
   NextButtonComponent: NextButton,
   DotComponent: Dot,
   imageContainerStyles: null,
-  allowFontScaling: true,
+  allowFontScalingText: true,
+  allowFontScalingButtons: true,
   titleStyles: null,
   subTitleStyles: null,
   transitionAnimationDuration: 500,


### PR DESCRIPTION
Add props `allowFontScalingText` and `allowFontScalingButtons` to pass the value on to `Text` components in the `Page` and button components, respectively.

This allows you to control whether or not Dynamic Type settings affect the title or subtitle on your pages.

Also adds props `titleStyles` and `subTitleStyles` to allow the opportunity to modify default styles of the title and subtitle.