### PR TITLE
Set useNativeDriver to avoid Warnings

### DIFF
--- a/src/buttons/DoneButton.js
+++ b/src/buttons/DoneButton.js
@@ -14,6 +14,7 @@ class DoneButton extends React.Component {
       Animated.timing(this.state.fadeAnim, {
         toValue: 1,
         duration: 1000,
+        useNativeDriver: true,
       }).start();
     }, 1000);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,8 @@ import DoneButton from './buttons/DoneButton';
 const itemVisibleHotfix = { itemVisiblePercentThreshold: 100 };
 
 class Onboarding extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       currentPage: 0,
@@ -39,6 +39,7 @@ class Onboarding extends Component {
     Animated.timing(this.state.backgroundColorAnim, {
       toValue: 1,
       duration: this.props.transitionAnimationDuration,
+      useNativeDriver: false,
     }).start();
   }
 


### PR DESCRIPTION
With React Native v0.62 onwards `useNativeDriver` is a required parameter which needs to be passed.
https://reactnative.dev/blog/2020/03/26/version-0.62#deprecations
https://github.com/facebook/react-native/commit/5876052615f4858ed5fc32fa3da9b64695974238