### PR TITLE
Fix issue with font scaling prop names

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Check out the three examples files: the [simple example](examples/Simple.js), th
 * `showPagination` (optional): whether to show the bottom pagination bar. Defaults to `true`.
 * `flatlistProps` (optional): additional props for the [FlatList](https://facebook.github.io/react-native/docs/flatlist.html) which holds all the pages.
 * `transitionAnimationDuration` (optional): The duration in milliseconds for the animation of the background color for the page transition. Defaults to `500`.
-* `allowFontScaling` (optional): Font scaling can cause troubles with high-resolution screens. You may want to disable it. Defaults to `true`.
+* `allowFontScalingText` (optional): Font scaling can cause troubles with high-resolution screens. You may want to disable it. Defaults to `true`.
+* `allowFontScalingButtons` (optional): Font scaling can cause troubles with high-resolution screens. You may want to disable it. Defaults to `true`.
 * `pageIndexCallback` (optional): a function that receives the page `index` as a parameter on page change. [Example Usage](https://github.com/jfilter/react-native-onboarding-swiper/pull/40)
 
 ### Default Page Styles


### PR DESCRIPTION
Hi there,

Just a quick Pull Request to fix an issue I came across when trying to disable font scaling. I'd added the `allowFontScaling` prop to `<Onboarding />`, as shown in the documentation, but when scaling my font size up in the iOS settings I noticed it wasn't working. Despite the documentation saying to use `allowFontScaling`, it's actually `allowFontScalingText` that's [passed](https://github.com/jfilter/react-native-onboarding-swiper/blob/master/src/index.js#L100) to the `<Page />` component so regardless of what you pass with `allowFontScaling`, the component just uses the [default value](https://github.com/jfilter/react-native-onboarding-swiper/blob/master/src/index.js#L290) of `true` for `allowFontScalingText`.

I wasn't sure if you wanted all the names refactored but for now, I just did the documentation so people can at least get it working without digging into the source code.

Thanks for all that you've done with this awesome component. ✌️ 