### PR TITLE
Removed width and height as Page props

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -7,8 +7,6 @@ const Page = ({
   image,
   title,
   subtitle,
-  width,
-  height,
   containerStyles,
   imageContainerStyles,
   allowFontScaling,
@@ -38,7 +36,7 @@ const Page = ({
   }
 
   return (
-    <View style={[styles.container, containerStyles, { width, height }]}>
+    <View style={[styles.container, containerStyles]}>
       <View style={[styles.imageContainer, imageContainerStyles]}>{image}</View>
       {titleElement}
       {subtitleElement}
@@ -65,8 +63,6 @@ Page.propTypes = {
   subTitleStyles: PropTypes.shape({
     style: PropTypes.any,
   }),
-  width: PropTypes.number.isRequired,
-  height: PropTypes.number.isRequired,
 };
 
 Page.defaultProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -29,8 +29,6 @@ class Onboarding extends Component {
     this.state = {
       currentPage: 0,
       previousPage: null,
-      width: null,
-      height: null,
       backgroundColorAnim: new Animated.Value(0),
     };
   }
@@ -76,8 +74,8 @@ class Onboarding extends Component {
   };
 
   _onLayout = () => {
-    const { width, height } = Dimensions.get('window');
-    this.setState({ width, height });
+    // const { width, height } = Dimensions.get('window');
+    // this.setState({ width, height });
   };
 
   keyExtractor = (item, index) => index.toString();
@@ -99,8 +97,6 @@ class Onboarding extends Component {
         image={image}
         title={title}
         subtitle={subtitle}
-        width={this.state.width || Dimensions.get('window').width}
-        height={this.state.height || Dimensions.get('window').height}
         containerStyles={containerStyles}
         imageContainerStyles={imageContainerStyles}
         allowFontScaling={allowFontScalingText}


### PR DESCRIPTION
`width` and `height` props were removed from the Page components because these parameters can be passed as containerStyles from the root component. Removing these props gives more freedom to customize the Obboarding root component.