### PR TITLE
Center the {image} in its parent View

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -90,7 +90,8 @@ const styles = {
   },
   imageContainer: {
     flex: 0,
-    paddingBottom: potrait ? 60 : 10,
+    padding:10,
+    justifyContent:'center',
     alignItems: 'center',
     width: '100%',
   },


### PR DESCRIPTION
image element should be at the center of its parent View so I used justifyContent:'center' and alignItems:'center' also paddingBottom was creating a problem when I wanted to put the image at the center of the View that has image as its child component.